### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ blessings == 1.5.1
 docopt == 0.6.1
 Flask == 0.10.1
 requests == 2.10.0
-stravalib == 0.5.0
+stravalib >= 0.6.5


### PR DESCRIPTION
Stravalib 0.5.0 is now out of date and throws errors when activities are returned from Strava.