### PR TITLE
Catch RateLimitExceeded exception thrown by the API and retry once.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ archive
 *.csv
 *.pyc
 *.gpx
+venv


### PR DESCRIPTION
Instead of keeping track of how many activity's we have synced catch …the RateLimitExceeded exception thrown by the API and retry once. This is more robust when the API limits will change from the strava ( which they did).

Also moved the location of "duplicate of activity" exception. This was actually being thrown by  upload.wait() and now client.upload_activity()/


Closes #23 


