### PR TITLE
Bump stravalib to 0.10.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 docopt == 0.6.1
 Flask == 1.0
 requests == 2.20.0
-stravalib == 0.10.2
+stravalib == 0.10.4


### PR DESCRIPTION
Fixes barrald#26 

Something changed with the Strava API, with stravalib `0.10.2`, it's not able to iterate through `activities` from `get_activities`. Bumping `stravalib` to `0.10.4` fixes it.

Adding manual activities still works, but I don't have any other gpx files to test the other path through `upload_activity()`